### PR TITLE
Add ABS logo (use permitted by ABS)

### DIFF
--- a/iNZight/about/sponsors/sponsors.Md
+++ b/iNZight/about/sponsors/sponsors.Md
@@ -17,8 +17,8 @@ We are proudly supported by &hellip;
     <img src="../../img/minedu_logo.png" alt="Ministry of Education">
   </a>
 
-  <!-- <a href="https://abs.gov.au">
+  <a href="https://abs.gov.au">
     <img src="https://oversixtydev.blob.core.windows.net/media/7831220/1.jpg" alt="Australian Bureau of Statistics">
-  </a> -->
+  </a>
 </div>
 ///


### PR DESCRIPTION
Ki Ora! Tom,

As the ABS logo is copyrighted, I have been able to grant you permission to use the ABS for research and educational purposes under Creative Commons 4.0 International.

Permission is granted for the use of ABS logo from the Australian Bureau of Statistics, as outlined in your email of  29 October 2020 under the Creative Commons Attribution 4.0 International licence.  

Please ensure:

the title of any and all ABS graphs are labelled as they appear in the publication;
ABS data is attributed to the ABS including a reference to the title, ABS catalogue number and date of publication  Attributing ABS Material  ;
data from other sources (including that derived from ABS statistics) is not attributed to the ABS; and
a link is provided back to the ABS website <www.abs.gov.au> (if appropriate).

If the ABS statistics are not used as indicated, or if there is a change in ABS policy, permission may be revoked. 


If you require further information, please contact us at intermediary.management@abs.gov.au 

Kind regards